### PR TITLE
Calculating neighbors of set S

### DIFF
--- a/HungarianAlgorithm/Hungarian/Hungarian.cs
+++ b/HungarianAlgorithm/Hungarian/Hungarian.cs
@@ -64,7 +64,8 @@ namespace Hungarian
                 while (path is null)
                 {
                     int nextT = -1;
-                    if (AreAllNeighborsInSet(eqGraph, S, T, areAllNeighborsInT, out Edge<int>? edgeToNextT))
+                    var edgesToNextTs = new List<Edge<int>>();
+                    if (AreAllNeighborsInSet(eqGraph, S, T, areAllNeighborsInT, out Edge<int>? _edgeToNextT))
                     {
                         decimal delta = WExceptT.Select(w => wellsSlackness[w]).Min();
                         foreach (int s in S)
@@ -94,9 +95,13 @@ namespace Hungarian
                         {
                             eqGraph.RemoveEdge(edge);
                         }
+
                         var newTVertices = WExceptT.Where(well => wellsSlackness[well] == 0.0m);
                         foreach (var well in newTVertices)
                         {
+                            // we add all tightened edges to the eqGraph,
+                            // but we need only one of them to add to the alternating tree
+                            Edge<int>? edgeToNewT = null;
                             foreach (var s in S)
                             {
                                 _graph.TryGetEdge(well, s, out var edge);
@@ -105,45 +110,61 @@ namespace Hungarian
                                 if (!eqGraph.ContainsEdge(well, s) && !eqGraph.ContainsEdge(s, well) &&
                                     cost == _graph.GetVertexLabel(well) + _graph.GetVertexLabel(s))
                                 {
-                                    edgeToNextT = new Edge<int>(s, well);
-                                    eqGraph.AddEdge(edgeToNextT);
-                                    areAllNeighborsInT[s] = false;
+                                    var newEqEdge = new Edge<int>(s, well);
+                                    eqGraph.AddEdge(newEqEdge);
+
+                                    //areAllNeighborsInT[s] = false;
+                                    if (edgeToNewT is null)
+                                        edgeToNewT = newEqEdge;
                                 }
                             }
+                            edgesToNextTs.Add(edgeToNewT!);
                         }
-                    }
-                    alternatingTree.AddEdge(edgeToNextT!);
-                    nextT = edgeToNextT!.Target;
-                    T.Add(nextT);
-                    WExceptT.Remove(nextT);
-
-                    // nextT is vertex from (N_p(S) \ T)
-                    var nextTMatchingEdge = Matching.Find(e => e.Source == nextT || e.Target == nextT);
-                    if (nextTMatchingEdge is null)
-                    {
-                        path = new List<Edge<int>>();
-
-                        Edge<int> pathEdge = edgeToNextT!;
-                        while (pathEdge.Source != free_s)
-                        {
-                            path.Add(pathEdge);
-                            pathEdge = alternatingTree.InEdges(pathEdge.Source).First();
-                        }
-                        path.Add(pathEdge);
                     }
                     else
                     {
-                        int newS = nextTMatchingEdge.GetOtherVertex(nextT);
-                        S.Add(newS);
-                        alternatingTree.AddEdge(new Edge<int>(nextT, newS));
-                        
-                        // SLACK:: update necessary values
-                        foreach (var well in WExceptT)
+                        // only one edge added to the list if we are here
+                        edgesToNextTs.Add(_edgeToNextT!);
+                    }
+
+                    // all of newTVertices need to be added to T
+                    // we can then process them all at once
+                    foreach (var edgeToNextT in edgesToNextTs)
+                    {
+                        alternatingTree.AddEdge(edgeToNextT!);
+                        nextT = edgeToNextT!.Target;
+                        T.Add(nextT);
+                        WExceptT.Remove(nextT);
+
+                        // nextT is vertex from (N_p(S) \ T)
+                        var nextTMatchingEdge = Matching.Find(e => e.Source == nextT || e.Target == nextT);
+                        if (nextTMatchingEdge is null)
                         {
-                            _graph.TryGetEdge(well, newS, out var edge);
-                            decimal newSSlackness = edge.Tag - _graph.GetVertexLabel(edge.Source) - _graph.GetVertexLabel(edge.Target);
-                            if (newSSlackness < wellsSlackness[well])
-                                wellsSlackness[well] = newSSlackness;
+                            path = new List<Edge<int>>();
+
+                            Edge<int> pathEdge = edgeToNextT!;
+                            while (pathEdge.Source != free_s)
+                            {
+                                path.Add(pathEdge);
+                                pathEdge = alternatingTree.InEdges(pathEdge.Source).First();
+                            }
+                            path.Add(pathEdge);
+                            break;  // we found the path, so we can break
+                        }
+                        else
+                        {
+                            int newS = nextTMatchingEdge.GetOtherVertex(nextT);
+                            S.Add(newS);
+                            alternatingTree.AddEdge(new Edge<int>(nextT, newS));
+                        
+                            // SLACK:: update necessary values
+                            foreach (var well in WExceptT)
+                            {
+                                _graph.TryGetEdge(well, newS, out var edge);
+                                decimal newSSlackness = edge.Tag - _graph.GetVertexLabel(edge.Source) - _graph.GetVertexLabel(edge.Target);
+                                if (newSSlackness < wellsSlackness[well])
+                                    wellsSlackness[well] = newSSlackness;
+                            }
                         }
                     }
                 }

--- a/HungarianAlgorithm/Hungarian/Hungarian.cs
+++ b/HungarianAlgorithm/Hungarian/Hungarian.cs
@@ -105,20 +105,15 @@ namespace Hungarian
                                     if (!eqGraph.ContainsEdge(well, s) && !eqGraph.ContainsEdge(s, well) &&
                                         cost == _graph.GetVertexLabel(well) + _graph.GetVertexLabel(s))
                                     {
-                                        var newEdge = new Edge<int>(s, well);
-                                        alternatingTree.AddEdge(newEdge);
-                                        eqGraph.AddEdge(newEdge);
-                                        nextT = edge.GetOtherVertex(s);
+                                        edgeToNextT = new Edge<int>(s, well);
+                                        eqGraph.AddEdge(edgeToNextT);
                                     }
                                 }
                             }
                         }
                     }
-                    else
-                    {
-                        alternatingTree.AddEdge(edgeToNextT!);
-                        nextT = edgeToNextT!.Target;
-                    }
+                    alternatingTree.AddEdge(edgeToNextT!);
+                    nextT = edgeToNextT!.Target;
                     T.Add(nextT);
 
                     // nextT is vertex from (N_p(S) \ T)
@@ -127,7 +122,7 @@ namespace Hungarian
                     {
                         path = new List<Edge<int>>();
 
-                        Edge<int> pathEdge = alternatingTree.InEdges(nextT).First();
+                        Edge<int> pathEdge = edgeToNextT!;
                         while (pathEdge.Source != free_s)
                         {
                             path.Add(pathEdge);

--- a/HungarianAlgorithm/Hungarian/Hungarian.cs
+++ b/HungarianAlgorithm/Hungarian/Hungarian.cs
@@ -108,6 +108,7 @@ namespace Hungarian
                                     {
                                         edgeToNextT = new Edge<int>(s, well);
                                         eqGraph.AddEdge(edgeToNextT);
+                                        areAllNeighborsInT[s] = false;
                                     }
                                 }
                             }
@@ -116,7 +117,7 @@ namespace Hungarian
                     alternatingTree.AddEdge(edgeToNextT!);
                     nextT = edgeToNextT!.Target;
                     T.Add(nextT);
-                    WExceptT.Remove(nextT.Value);
+                    WExceptT.Remove(nextT);
 
                     // nextT is vertex from (N_p(S) \ T)
                     var nextTMatchingEdge = Matching.Find(e => e.Source == nextT || e.Target == nextT);

--- a/HungarianAlgorithm/Hungarian/Hungarian.cs
+++ b/HungarianAlgorithm/Hungarian/Hungarian.cs
@@ -226,12 +226,6 @@ namespace Hungarian
             return new Solution(assignments);
         }
 
-        /// <param name="freeNeighbour">
-        ///     Vertex adjacent in graph <paramref name="graph"/> to <paramref name="fromS"/> from <paramref name="sourcesSet"/>.
-        ///     Set only if <c>false</c> returned.
-        /// </param>
-        /// <param name="fromS">Set only if <paramref name="freeNeighbour"/> set.</param>
-        /// <returns></returns>
         private bool AreAllNeighborsInSet(IImplicitGraph<int, Edge<int>> graph, ISet<int> sourcesSet, ISet<int> neighboursSet,
             bool[] allNeighborsDone, out Edge<int>? edgeToNextT)
         {

--- a/HungarianAlgorithm/Hungarian/Hungarian.cs
+++ b/HungarianAlgorithm/Hungarian/Hungarian.cs
@@ -94,22 +94,20 @@ namespace Hungarian
                         {
                             eqGraph.RemoveEdge(edge);
                         }
-                        foreach (var well in WExceptT)
+                        var newTVertices = WExceptT.Where(well => wellsSlackness[well] == 0.0m);
+                        foreach (var well in newTVertices)
                         {
-                            if (wellsSlackness[well] == 0.0m)
+                            foreach (var s in S)
                             {
-                                foreach (var s in S)
-                                {
-                                    _graph.TryGetEdge(well, s, out var edge);
-                                    var cost = edge.Tag;
+                                _graph.TryGetEdge(well, s, out var edge);
+                                var cost = edge.Tag;
 
-                                    if (!eqGraph.ContainsEdge(well, s) && !eqGraph.ContainsEdge(s, well) &&
-                                        cost == _graph.GetVertexLabel(well) + _graph.GetVertexLabel(s))
-                                    {
-                                        edgeToNextT = new Edge<int>(s, well);
-                                        eqGraph.AddEdge(edgeToNextT);
-                                        areAllNeighborsInT[s] = false;
-                                    }
+                                if (!eqGraph.ContainsEdge(well, s) && !eqGraph.ContainsEdge(s, well) &&
+                                    cost == _graph.GetVertexLabel(well) + _graph.GetVertexLabel(s))
+                                {
+                                    edgeToNextT = new Edge<int>(s, well);
+                                    eqGraph.AddEdge(edgeToNextT);
+                                    areAllNeighborsInT[s] = false;
                                 }
                             }
                         }


### PR DESCRIPTION
Ten PR zawiera usprawnienie funkcji `AreAllNeighborsInSet` (przede wszystkim pierwszy commit). Problem był taki, że naiwnie lecieliśmy po wszystkich wierzchołkach ze zbioru `S` za każdym razem.
~~Podczas gdy w rzeczywistości, kiedy wszyscy sąsiedzi jakiegoś `s` są już dodani do `T`, to nie ma potrzeby go sprawdzać w kolejnych iteracjach (każdy potencjalny nowy sąsiad jest od razu dodawany do `T`).~~

Myślałem nad dwoma podejściami do rozwiązania tego, każde z nich polega na przechowywaniu jakiejś tablicy z dodatkowymi informacjami o wierzchołkach z `S`.
Ostatecznie wybrałem to drugie, ale zapiszę oba, bo może przyda się to do dokumentacji końcowej, albo może będzie szansa zrobić jakieś porównanie (lokalnie mam też tę pierwszą wersję) 🙂
1. Utrzymujemy listę OutEdges(s), ale tylko krawędzi, które prowadzą do wierzchołków, których nie mamy jeszcze w `T`
  - **Zysk**: mamy szybki, liniowy dostęp do krawędzi `edgeToNextT` - wystarczy, że weźmiemy pierwszą z brzegu
  - Dodanie wierzchołka do `T` sprawia, że musimy przeliczyć listy wszystkich pozostałych wierzchołków z `S`
  - Dodanie wierzchołka do `S` sprawia, że musimy obliczyć dla niego poprawną listę
2. Mamy listę booli, która mówi tylko o tym, czy `s` ma (potencjalnie) jeszcze jakichś sąsiadów poza `T`
  - Dodając nowy wierzchołek do `S` nie przejmujemy się niczym - po prostu ustawiamy `false`
  - Podobnie z `T` - nic nie przeliczamy
  - Modyfikujemy funkcję `AreAllNeighborsInSet` tak, żeby przeglądała tylko te wierzchołki z `S`, dla których mamy `false`. Ona też zajmuje się ustawianiem ich na `true`

Nie jestem pewien złożoności pierwszego rozwiązania, ale jak tak teraz myślę, to wydaje mi się, że zastosowanie tego drugiego spada nam operację `AreAllNeighborsInSet` do liniowej? 😀